### PR TITLE
カードの効果を実行する処理をまとめる

### DIFF
--- a/class/card.rb
+++ b/class/card.rb
@@ -1,5 +1,11 @@
 class Card
   attr_accessor :name, :cost, :type, :atk, :def, :eff
+
+  def action(player)
+    player.atk = atk
+    player.def = @def
+    player.en -= cost
+  end
 end
 
 class Fight < Card

--- a/module/battle.rb
+++ b/module/battle.rb
@@ -40,15 +40,13 @@ module Battle
       player.nameplate.delete_at(card_number - 1)
       puts card.name
 
-      attack = calc_player_attack(player, card)
-      defense = enemy.def
-      damage = calc_damage(attack, defense)
+      card.action(player)
+      damage = calc_damage(player.atk, enemy.def)
       puts "#{damage}のダメージをあたえた"
       calc_remaining_hp(enemy, damage)
 
       return if is_zero_hp(enemy)
 
-      calc_remaining_en(player, card)
       turn_continue = turn_select(turn_continue)
     end
     player.en = MAX_ENERGY if player.en < MAX_ENERGY
@@ -57,9 +55,7 @@ module Battle
 
   def enemy_turn(player, enemy)
     display_enemy_attack(enemy)
-    attack = enemy.atk
-    defense = player.def
-    damage = calc_damage(attack, defense)
+    damage = calc_damage(enemy.atk, player.def)
     puts "#{damage}のダメージをうけた"
     calc_remaining_hp(player, damage)
   end
@@ -140,20 +136,12 @@ module Battle
     puts "GAME OVER"
   end
 
-  def calc_player_attack(player, card)
-    player.atk + card.atk
-  end
-
   def calc_damage(attack, defense)
     attack - defense
   end
 
   def calc_remaining_hp(character, damage)
     character.hp -= damage
-  end
-
-  def calc_remaining_en(player, card)
-    player.en -= card.cost
   end
 
   def is_zero_hp(character)


### PR DESCRIPTION
- カードによってプレイヤーのatk,def,enを変化させる処理を関数としてまとめる
- カード実行時にプレイヤーのステータスが変化させる
- エネルギー消費処理はカード実行時に行うため、既存の関数は削除
- カード実行時にプレイヤーのステータスを変化させるため、攻撃力計算処理は削除