### PR TITLE
攻撃力をカードアクション後に初期化する

### DIFF
--- a/module/battle.rb
+++ b/module/battle.rb
@@ -45,6 +45,7 @@ module Battle
       damage = calc_damage(enemy, player.attack)
       puts "#{damage}のダメージをあたえた"
       calc_remaining_hp(enemy, damage)
+      player.attack -= card.attack
 
       return if is_zero_hp(enemy)
 


### PR DESCRIPTION
- 攻撃力はカード毎に切り替えるため、アクション後に初期化する
- 初期化する際は、カードの攻撃力分だけ引く（プレーヤー自身の攻撃力があるため）