### PR TITLE
エネルギーが足りない時のエラーチェック

### DIFF
--- a/class/card.rb
+++ b/class/card.rb
@@ -2,9 +2,21 @@ class Card
   attr_accessor :name, :cost, :type, :attack, :defense, :eff
 
   def action(player)
-    player.attack = attack
-    player.defense += defense
-    player.energy -= cost
+    is_useful = false
+    if is_remaining_energy(player)
+      is_useful = true
+      player.attack = attack
+      player.defense += defense
+      player.energy -= cost
+    else
+      return is_useful
+    end
+    is_useful
+  end
+
+  def is_remaining_energy(player)
+    remaining_energy = player.energy - cost
+    remaining_energy >= 0 ? true : false
   end
 end
 

--- a/module/battle.rb
+++ b/module/battle.rb
@@ -33,15 +33,21 @@ module Battle
       player.deck_shuffle
     end
     card_draw(player)
-    while turn_continue && player.energy > 0 do
+    while turn_continue do
       display_player_status(player)
       card_number = card_select(player)
       card = player.nameplate[card_number - 1]
-      player.cemetery.push(card)
-      player.nameplate.delete_at(card_number - 1)
+      is_card_useful = card.action(player)
+      unless is_card_useful
+        puts "エネルギーが足りません"
+        turn_continue = turn_select(turn_continue)
+        turn_continue ? next : break
+      end
       puts card.name
 
-      card.action(player)
+      player.cemetery.push(card)
+      player.nameplate.delete_at(card_number - 1)
+
       damage = calc_damage(enemy, player.attack)
       puts "#{damage}のダメージをあたえた"
       calc_remaining_hp(enemy, damage)


### PR DESCRIPTION
- プレイヤーのエネルギーが0でもカード選択メッセージを表示する（0コストカードが追加された時のため）
- プレイヤーのエネルギーが0より低くなった時、エラーメッセージを表示する
- エラーメッセージ後にターン選択メッセージを表示する